### PR TITLE
replace broken base URL

### DIFF
--- a/scraper.rb
+++ b/scraper.rb
@@ -11,7 +11,7 @@ require 'uri'
 
 def json_from(filename)
   JSON.parse(open(URI.join(
-    'https://raw.githubusercontent.com/openpatata/openpatata-data/export/',
+    'https://cdn.rawgit.com/openpatata/openpatata-data/export/',
     filename)).read, symbolize_names: true)
 end
 


### PR DESCRIPTION
Scraper was failing with error message:
`/app/vendor/ruby-2.0.0/lib/ruby/2.0.0/open-uri.rb:353:in`open_http': 404 Not Found (OpenURI::HTTPError)`

Fixed by replacing base URL

Fixes https://github.com/everypolitician/everypolitician-data/issues/14877
